### PR TITLE
Modification des adapter et serializers pour connexion avec API Spring

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,13 +1,8 @@
-import DS from 'ember-data';
 import ENV from "story-heroes/config/environment";
-import JSONAPIAdapter from '@ember-data/adapter/json-api'
-const api = "http://localhost:8080"
+import RESTAdapter from '@ember-data/adapter/rest';
 
-
-
-
-export default JSONAPIAdapter.extend({
-    host: api,
+export default RESTAdapter.extend({
+    host: ENV.apiUrl,
     handleResponse(status, headers, payload) {
         if (status !== 200 && payload && payload.message) {
             return payload;

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,4 +1,4 @@
-import JSONAPISerializer from '@ember-data/serializer/json-api';
+import JSONSerializer from '@ember-data/serializer/json';
 
-export default class ApplicationSerializer extends JSONAPISerializer {
+export default class ApplicationSerializer extends JSONSerializer {
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function(environment) {
         ENV.baseURL = null;
         ENV.rootURL = null;
         ENV.locationType = 'hash';
-        ENV.apiUrl = process.env.API_URL;
+        ENV.apiUrl = 'http://localhost:8080';
     }
 
     if (environment === 'test') {


### PR DESCRIPTION
J'ai remis le RESTAdapter et j'ai mis par contre le JSONSerializer, plus tolérant que le JSONAPISerializer. De mon côté ça marche en tout cas. Concernant la conf, j'ai remplacé dans environment.js apiUrl avec la valeur directe. Vous pourrez retester en mettant la valeur issue de la variable d'environnement.

Bon courage pour la suite !